### PR TITLE
update for cordova 8, android platform7.  added example

### DIFF
--- a/example/touch.js
+++ b/example/touch.js
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+//Use after a cordova create (new project)
+//Edit the index.html and add a script tag for this touch.js file under the existing index.js file
+//copy this file into the js directory
+//Excercises the general API for this plugin
+var app = {
+    // Application Constructor
+    initialize: function() {
+        document.addEventListener('deviceready', this.onDeviceReady.bind(this), false);
+    },
+
+    // deviceready Event Handler
+    //
+    // Bind any cordova events here. Common events are:
+    // 'pause', 'resume', etc.
+    onDeviceReady: function() {
+        if (window.plugins) {
+	    //save
+            window.plugins.touchid.save("MyKey", "My Password", function() {
+                alert("Password saved");
+
+                //biometricsType
+                window.plugins.touchid.biometricType(function(value) { alert("Biometrics: " + value); }, 
+                function() { alert("Biometric error");} );
+
+	        //isAvailable
+    	        window.plugins.touchid.isAvailable(function() {
+
+                    //has
+                    window.plugins.touchid.has("MyKey", function() {
+                        alert("Touch ID avaialble and Password key available");
+
+	               //verify
+                       window.plugins.touchid.verify("MyKey", "My Message", function(password) {
+                           alert("Touch " + password);
+
+	                   //delete	
+                           window.plugins.touchid.delete("MyKey", function() {
+                               alert("Password key deleted");
+                           });
+                       });
+                    }, function() {
+                        alert("Touch ID available but no Password Key available");
+                    });
+                }, function(msg) {
+                    alert("no Touch ID available");
+                });
+            });
+        }
+    }
+};
+
+app.initialize();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-keychain-touch-id",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Scan the fingerprint of your user with the TouchID sensor (iPhone 5S, iPhone 6(S), ..) and control a key in the Keychain",
   "cordova": {
     "id": "cordova-plugin-keychain-touch-id",
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id.git"
+    "url": "git+https://github.com/paychex/cordova-plugin-keychain-touch-id.git"
   },
   "keywords": [
     "TouchID",
@@ -25,15 +25,23 @@
   "engines": [
     {
       "name": "cordova",
-      "version": ">=3.0.0"
+      "version": ">=8.0.0"
+    },
+    {
+      "name": "cordova-andoird",
+      "version": ">=7.0.0"
+    },
+    {
+      "name": "cordova-ios",
+      "version": ">=4.5.0"
     }
   ],
   "author": "S.J.Hoeksma",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id/issues"
+    "url": "https://github.com/paychex/cordova-plugin-keychain-touch-id/issues"
   },
-  "homepage": "https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id#readme",
+  "homepage": "https://github.com/paychex/cordova-plugin-keychain-touch-id#readme",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
       "version": ">=8.0.0"
     },
     {
-      "name": "cordova-andoird",
+      "name": "cordova-android",
       "version": ">=7.0.0"
     },
     {

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-keychain-touch-id"
-		version="3.2.2">
+		version="3.3.0">
     <name>TouchID and Keychain</name>
 	  <author>S.J.Hoeksma</author>
     <description>TouchID and Keychain cordova plugin for iOS</description>
     <license>Apache 2.0</license>
     <keywords>cordova,touchid,keychain,plugin</keywords>
     <engines>
-      <engine name="cordova" version=">=3.0.0"/>
+      <engine name="cordova" version=">=8.0.0"/>
     </engines>
 
-    <repo>https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id.git</repo>
-    <issue>https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id/issues</issue>
+    <repo>https://github.com/paychex/cordova-plugin-keychain-touch-id.git</repo>
+    <issue>https://github.com/paychex/cordova-plugin-keychain-touch-id/issues</issue>
 	  <js-module src="www/touchid.js" name="TouchID">
         <clobbers target="window.plugins.touchid" />
     </js-module>
@@ -34,32 +34,32 @@
 
     <!-- android -->
     <platform name="android">
-        <config-file target="res/xml/config.xml" parent="/*">
+        <config-file target="app/src/main/res/xml/config.xml" parent="/*">
             <feature name="TouchID" >
                 <param name="android-package" value="com.cordova.plugin.android.fingerprintauth.FingerprintAuth"/>
             </feature>
         </config-file>
-        <config-file target="AndroidManifest.xml" parent="/*">
+        <config-file target="app/src/main/AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.USE_FINGERPRINT" />
             <!--<uses-sdk android:minSdkVersion="23" android:targetSdkVersion="23" />-->
         </config-file>
 
-        <source-file src="src/android/FingerprintAuth.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
-        <source-file src="src/android/FingerprintAuthenticationDialogFragment.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
-        <source-file src="src/android/FingerprintUiHelper.java" target-dir="src/com/cordova/plugin/android/fingerprintauth" />
-        <source-file src="res/android/drawable/ic_fingerprint_error.xml" target-dir="res/drawable" />
-        <source-file src="res/android/drawable/ic_fingerprint_success.xml" target-dir="res/drawable" />
-        <source-file src="res/android/drawable-hdpi/ic_fp_40px.png" target-dir="res/drawable-hdpi" />
-        <source-file src="res/android/drawable-mdpi/ic_fp_40px.png" target-dir="res/drawable-mdpi" />
-        <source-file src="res/android/drawable-nodpi/android_robot.png" target-dir="res/drawable-nodpi" />
-        <source-file src="res/android/drawable-xhdpi/ic_fp_40px.png" target-dir="res/drawable-xhdpi" />
-        <source-file src="res/android/drawable-xxhdpi/ic_fp_40px.png" target-dir="res/drawable-xxhdpi" />
-        <source-file src="res/android/drawable-xxxhdpi/ic_fp_40px.png" target-dir="res/drawable-xxxhdpi" />
-        <source-file src="res/android/layout/fingerprint_dialog_container.xml" target-dir="res/layout" />
-        <source-file src="res/android/layout/fingerprint_dialog_content.xml" target-dir="res/layout" />
-        <source-file src="res/android/values/fpauth-colors.xml" target-dir="res/values" />
-        <source-file src="res/android/values/fpauth-strings.xml" target-dir="res/values" />
-        <source-file src="res/android/values-es/fpauth-strings.xml" target-dir="res/values-es" />
+        <source-file src="src/android/FingerprintAuth.java" target-dir="app/src/main/java/com/cordova/plugin/android/fingerprintauth" />
+        <source-file src="src/android/FingerprintAuthenticationDialogFragment.java" target-dir="app/src/main/java/com/cordova/plugin/android/fingerprintauth" />
+        <source-file src="src/android/FingerprintUiHelper.java" target-dir="app/src/main/java/com/cordova/plugin/android/fingerprintauth" />
+        <source-file src="res/android/drawable/ic_fingerprint_error.xml" target-dir="app/src/main/res/drawable" />
+        <source-file src="res/android/drawable/ic_fingerprint_success.xml" target-dir="app/src/main/res/drawable" />
+        <source-file src="res/android/drawable-hdpi/ic_fp_40px.png" target-dir="app/src/main/res/drawable-hdpi" />
+        <source-file src="res/android/drawable-mdpi/ic_fp_40px.png" target-dir="app/src/main/res/drawable-mdpi" />
+        <source-file src="res/android/drawable-nodpi/android_robot.png" target-dir="app/src/main/res/drawable-nodpi" />
+        <source-file src="res/android/drawable-xhdpi/ic_fp_40px.png" target-dir="app/src/main/res/drawable-xhdpi" />
+        <source-file src="res/android/drawable-xxhdpi/ic_fp_40px.png" target-dir="app/src/main/res/drawable-xxhdpi" />
+        <source-file src="res/android/drawable-xxxhdpi/ic_fp_40px.png" target-dir="app/src/main/res/drawable-xxxhdpi" />
+        <source-file src="res/android/layout/fingerprint_dialog_container.xml" target-dir="app/src/main/res/layout" />
+        <source-file src="res/android/layout/fingerprint_dialog_content.xml" target-dir="app/src/main/res/layout" />
+        <source-file src="res/android/values/fpauth-colors.xml" target-dir="app/src/main/res/values" />
+        <source-file src="res/android/values/fpauth-strings.xml" target-dir="app/src/main/res/values" />
+        <source-file src="res/android/values-es/fpauth-strings.xml" target-dir="app/src/main/res/values-es" />
 
     </platform>
 </plugin>

--- a/readme.md
+++ b/readme.md
@@ -17,7 +17,7 @@ $ cordova prepare
 
 The latest, from the master repo:
 ```
-$ cordova plugin add https://github.com/sjhoeksma/cordova-plugin-keychain-touch-id
+$ cordova plugin add https://github.com/paychex/cordova-plugin-keychain-touch-id
 $ cordova prepare
 ```
 


### PR DESCRIPTION
added an example that can be dropped into a basic cordova create project for testing.  Also updated to work with cordova 8/android platform 7.  This is not backwards compatible due to the file/path structure changes made by cordova for android.  ios is not changed.  API is not changed.  Bumped the version number to 3.3.0